### PR TITLE
Add `build-tool-depends` for `hspec-discovery`

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -45,5 +45,7 @@ tests:
     - text-conversions
     - bytestring
     - hspec
-    - hspec-discover
     - text
+    verbatim: |
+      build-tool-depends:
+          hspec-discovery:hspec-discovery


### PR DESCRIPTION
Otherwise there is no metadata that this executable is needed, and
`cabal new-build` (and maybe soon Nix) will fail. OTOH this also 
means the regular `build-depends` isn't needed, and indeed this is
important for cross compilation.