### PR TITLE
Add ToText instance for Char

### DIFF
--- a/src/Data/Text/Conversions.hs
+++ b/src/Data/Text/Conversions.hs
@@ -143,6 +143,7 @@ convertText = fromText . toText
 decodeConvertText :: (DecodeText f a, FromText b) => a -> f b
 decodeConvertText = fmap fromText . decodeText
 
+instance ToText   Char    where toText   = T.singleton
 instance ToText   T.Text  where toText   = id
 instance FromText T.Text  where fromText = id
 instance ToText   String  where toText   = T.pack


### PR DESCRIPTION
Like the title says. Super simple change to allow Char to be converted directly to other textual types as if it was a one-character string instead of having to manually convert to something else first.