### PR TITLE
Support for `base16-bytestring-1.0.0.0`

### DIFF
--- a/src/Data/Text/Conversions.hs
+++ b/src/Data/Text/Conversions.hs
@@ -161,8 +161,8 @@ instance ToText (Base16 B.ByteString) where
 instance FromText (Maybe (Base16 B.ByteString)) where
 #if MIN_VERSION_base16_bytestring(1,0,0)
   fromText txt = case Base16.decode (T.encodeUtf8 txt) of
-    Right bs -> Just (Base16 bs)
-    Left{} -> Nothing
+    Right bs -> Just $ Base16 bs
+    Left   _ -> Nothing
 #else
   fromText txt = case Base16.decode (T.encodeUtf8 txt) of
     (bs, "") -> Just $ Base16 bs
@@ -179,8 +179,8 @@ instance ToText (Base16 BL.ByteString) where
 instance FromText (Maybe (Base16 BL.ByteString)) where
 #if MIN_VERSION_base16_bytestring(1,0,0)
   fromText txt = case Base16L.decode (TL.encodeUtf8 $ TL.fromStrict txt) of
-    Right bs -> Just (Base16 bs)
-    Left{} -> Nothing
+    Right bs -> Just $ Base16 bs
+    Left _   -> Nothing
 #else
   fromText txt = case Base16L.decode (TL.encodeUtf8 $ TL.fromStrict txt) of
     (bs, "") -> Just $ Base16 bs

--- a/src/Data/Text/Conversions.hs
+++ b/src/Data/Text/Conversions.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveFunctor #-}
 
 {-|
@@ -158,9 +159,15 @@ instance FromText         (UTF8 BL.ByteString) where fromText   = UTF8 . TL.enco
 instance ToText (Base16 B.ByteString) where
   toText = T.decodeUtf8 . Base16.encode . unBase16
 instance FromText (Maybe (Base16 B.ByteString)) where
+#if MIN_VERSION_base16_bytestring(1,0,0)
+  fromText txt = case Base16.decode (T.encodeUtf8 txt) of
+    Right bs -> Just (Base16 bs)
+    Left{} -> Nothing
+#else
   fromText txt = case Base16.decode (T.encodeUtf8 txt) of
     (bs, "") -> Just $ Base16 bs
     (_,  _)  -> Nothing
+#endif
 
 instance ToText (Base64 B.ByteString) where
   toText = T.decodeUtf8 . Base64.encode . unBase64
@@ -170,9 +177,15 @@ instance FromText (Maybe (Base64 B.ByteString)) where
 instance ToText (Base16 BL.ByteString) where
   toText = TL.toStrict . TL.decodeUtf8 . Base16L.encode . unBase16
 instance FromText (Maybe (Base16 BL.ByteString)) where
+#if MIN_VERSION_base16_bytestring(1,0,0)
+  fromText txt = case Base16L.decode (TL.encodeUtf8 $ TL.fromStrict txt) of
+    Right bs -> Just (Base16 bs)
+    Left{} -> Nothing
+#else
   fromText txt = case Base16L.decode (TL.encodeUtf8 $ TL.fromStrict txt) of
     (bs, "") -> Just $ Base16 bs
     (_,  _)  -> Nothing
+#endif
 
 instance ToText (Base64 BL.ByteString) where
   toText = TL.toStrict . TL.decodeUtf8 . Base64L.encode . unBase64

--- a/src/Data/Text/Conversions.hs
+++ b/src/Data/Text/Conversions.hs
@@ -162,7 +162,7 @@ instance FromText (Maybe (Base16 B.ByteString)) where
 #if MIN_VERSION_base16_bytestring(1,0,0)
   fromText txt = case Base16.decode (T.encodeUtf8 txt) of
     Right bs -> Just $ Base16 bs
-    Left   _ -> Nothing
+    Left _   -> Nothing
 #else
   fromText txt = case Base16.decode (T.encodeUtf8 txt) of
     (bs, "") -> Just $ Base16 bs


### PR DESCRIPTION
See: [#14](https://github.com/haskell/base16-bytestring/issues/14). Tested with the following in `stack.yaml`: 

```yaml
extra-deps:
  - base16-bytestring-1.0.0.0
```

This is both backcompatible with `<1.0` versions and forward compatible with `^>=1.0` versions.